### PR TITLE
log important/useful details when loading a new cert

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,35 @@ jobs:
       - save-go-mod-cache
       - save-workspace
 
+  tag-version:
+    executor: go-build
+    steps:
+      - restore-workspace
+      # commands
+      - run: |
+          curl -s https://api.github.com/repos/pantheon-systems/autotag/releases/latest | \
+            grep browser_download | \
+            grep -i linux | \
+            cut -d '"' -f 4 | \
+            xargs curl -o ~/autotag -L \
+            && chmod 755 ~/autotag
+      - run: ~/autotag
+      - run: |
+          # stdout and stderr redirected to null to prevent leaking the token on error.
+          # to debug failures re-run this job with ssh
+          git push -q --tags \
+            --repo=https://${GITHUB_TOKEN}@github.com/pantheon-systems/certinel \
+            >/dev/null 2>&1
+
 workflows:
   version: 2
   primary:
     jobs:
       - test
+      - tag-version:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
       - run: go test -v ./pollwatcher/...
       - run: go test -v ./fswatcher/...
       - run: go test -v .
+      - run: go test -run=XXX -bench=.
       # persist
       - save-go-mod-cache
       - save-workspace

--- a/certinel.go
+++ b/certinel.go
@@ -59,7 +59,8 @@ func (c *Certinel) Watch() {
 		for {
 			select {
 			case certificate := <-tlsChan:
-				c.log.Printf("Loading new certificate")
+				c.log.Printf("Loading new certificate: Subject: '%s', NotBefore: '%s', NotAfter: '%s'",
+					certificate.Leaf.Subject, certificate.Leaf.NotBefore, certificate.Leaf.NotAfter)
 				c.certificate.Store(&certificate)
 			case err := <-errChan:
 				c.errBack(err)

--- a/certinel_test.go
+++ b/certinel_test.go
@@ -2,6 +2,8 @@ package certinel
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"testing"
 	"time"
 
@@ -28,7 +30,16 @@ func (o *MockWatcher) Close() error {
 func TestGetCertificate(t *testing.T) {
 	tlsChan := make(chan tls.Certificate)
 	errChan := make(chan error)
-	cert := tls.Certificate{}
+	cert := tls.Certificate{
+		Certificate: [][]byte{
+			[]byte("Hello"),
+		},
+		Leaf: &x509.Certificate{
+			Subject:   pkix.Name{CommonName: "foo"},
+			NotBefore: time.Now(),
+			NotAfter:  time.Now(),
+		},
+	}
 	clientHello := &tls.ClientHelloInfo{}
 	watcher := &MockWatcher{}
 
@@ -67,10 +78,20 @@ func TestGetCertificateAfterChange(t *testing.T) {
 		Certificate: [][]byte{
 			[]byte("Hello"),
 		},
+		Leaf: &x509.Certificate{
+			Subject:   pkix.Name{CommonName: "cert1"},
+			NotBefore: time.Now(),
+			NotAfter:  time.Now(),
+		},
 	}
 	cert2 := tls.Certificate{
 		Certificate: [][]byte{
 			[]byte("Goodbye"),
+		},
+		Leaf: &x509.Certificate{
+			Subject:   pkix.Name{CommonName: "cert2"},
+			NotBefore: time.Now(),
+			NotAfter:  time.Now(),
 		},
 	}
 	clientHello := &tls.ClientHelloInfo{}


### PR DESCRIPTION
Two commits:

1. Update the log message emitted during cert reload:

Previous: 
```
Loading new certificate
```

new:
```
Loading new certificate: Subject: 'CN=github-bot-1,L=California,C=US', NotBefore: '2019-05-18 13:32:41 +0000 UTC', NotAfter: '2019-06-17 13:32:41 +0000 UTC'
```

2. Implemented `autotag` to generate new version tags on every master commit.  See autotag readme for more info. Summary: on a typical master build the Patch version will be incremented. The Major and Minor versions can be bumped by including "`[major]'`" or "`[minor]'`" in a commit message